### PR TITLE
Restore password decoding

### DIFF
--- a/noip-renew.py
+++ b/noip-renew.py
@@ -74,7 +74,7 @@ class Robot:
         ele_usr = self.browser.find_element(By.XPATH, "//form[@id='clogs']/input[@name='username']")
         ele_pwd = self.browser.find_element(By.XPATH, "//form[@id='clogs']/input[@name='password']")
         ele_usr.send_keys(self.username)
-        ele_pwd.send_keys(self.password)
+        ele_pwd.send_keys(base64.b64decode(self.password).decode('utf-8'))
         self.browser.find_element(By.XPATH, "//form[@id='clogs']/button[@type='submit']").click()
         if self.debug > 1:
             time.sleep(1)


### PR DESCRIPTION
As @Angel0ffDeath discovered, the password is base64 encoded when setup.sh is run.  Thus you can't just pass the encoded password to the field, it won't match the correct password.
 ele_pwd.send_keys(base64.b64decode(self.password).decode('utf-8'))  will decode the password back to the acceptable text.