### PR TITLE
sudo not required and creates complications

### DIFF
--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 USER=
-SUDO=sudo
+
 LOGDIR=/var/log/noip-renew/$USER
 INSTDIR=/usr/local/bin
 INSTEXE=$INSTDIR/noip-renew-$USER.sh
 CRONJOB="30 0 * * *   $USER    $INSTEXE $LOGDIR"
 NEWCJOB="30 0 $1 $2 *   $USER    $INSTEXE $LOGDIR"
-$SUDO crontab -u $USER -l | grep -v '/noip-renew*'  | $SUDO crontab -u $USER -
+crontab -u $USER -l | grep -v '/noip-renew*' | crontab -u $USER -
 if [[ $3 = "True" ]]; then
-    ($SUDO crontab -u $USER -l; echo "$NEWCJOB") | $SUDO crontab -u $USER -
+    ( crontab -u $USER -l; echo "$NEWCJOB") | crontab -u $USER -
 else
-    ($SUDO crontab -u $USER -l; echo "$CRONJOB") | $SUDO crontab -u $USER -
+    (crontab -u $USER -l; echo "$CRONJOB") | crontab -u $USER -
 fi
 
 exit 0


### PR DESCRIPTION
This script was designed to be run by a non privileged user.  A user doesn't need sudo to edit their own crontab.
sudo prompts for a password, so if cron runs this in the background after a successful execution of /usr/local/bin/noip-renew-myusername.sh, it will wait for a password and never update crontab.