### PR TITLE
Change log level to 2 in line 13.

### DIFF
--- a/noip-renew.sh
+++ b/noip-renew.sh
@@ -10,5 +10,5 @@ if [ -z "$LOGDIR" ]; then
     $PROGDIR/noip-renew.py "$USERNAME" "$PASSWORD" 2
 else
     cd $LOGDIR
-    $PROGDIR/noip-renew.py "$USERNAME" "$PASSWORD" 0 >> $USERNAME.log
+    $PROGDIR/noip-renew.py "$USERNAME" "$PASSWORD" 2 >> $USERNAME.log
 fi


### PR DESCRIPTION
Running:
`/usr/local/bin/noip-renew-myusername.sh /var/log/noip-renew/myusername
fails while running:
'/usr/local/bin/noip-renew-myusername.sh
succeeds.
@peteakalad determined that log level 2 adds enough delay for the page loads to work.