### PR TITLE
Updated Login and all sleeps removed

### DIFF
--- a/noip-renew.py
+++ b/noip-renew.py
@@ -17,6 +17,8 @@ from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from datetime import date
 from datetime import timedelta
 import time
@@ -68,17 +70,31 @@ class Robot:
     def login(self):
         self.logger.log(f"Opening {Robot.LOGIN_URL}...")
         self.browser.get(Robot.LOGIN_URL)
+        
+        try:
+            elem = WebDriverWait(self.browser, 10).until( EC.presence_of_element_located((By.ID, "signup-wrap")))
+        except:
+            raise Exception("Login page could not be loaded")
+            
         if self.debug > 1:
             self.browser.save_screenshot("debug1.png")
 
         self.logger.log("Logging in...")
-        ele_usr = self.browser.find_element(By.XPATH, "//form[@id='clogs']/input[@name='username']")
-        ele_pwd = self.browser.find_element(By.XPATH, "//form[@id='clogs']/input[@name='password']")
+#        ele_usr = self.browser.find_element(By.XPATH, "//form[@id='clogs']/input[@name='username']")
+#        ele_pwd = self.browser.find_element(By.XPATH, "//form[@id='clogs']/input[@name='password']")
+        
+        ele_usr = elem.find_element(By.NAME, "username")
+        ele_pwd = elem.find_element(By.NAME, "password")
+        
         ele_usr.send_keys(self.username)
         ele_pwd.send_keys(base64.b64decode(self.password).decode('utf-8'))
         ele_pwd.send_keys(Keys.ENTER)
+        
+        # After Loggin browser loads my.noip.com page - give him some time to load
+        self.browser.implicitly_wait(1)
+
         if self.debug > 1:
-            time.sleep(1)
+#            time.sleep(1)
             self.browser.save_screenshot("debug2.png")
 
     def update_hosts(self):

--- a/noip-renew.py
+++ b/noip-renew.py
@@ -91,7 +91,11 @@ class Robot:
         ele_pwd.send_keys(Keys.ENTER)
         
         # After Loggin browser loads my.noip.com page - give him some time to load
-        self.browser.implicitly_wait(1)
+        # 'noip-cart' element is near the end of html, so html have been loaded
+        try:
+            elem = WebDriverWait(self.browser, 10).until( EC.presence_of_element_located((By.ID, "noip-cart")))
+        except:
+            raise Exception("my.noip.com page could not load")        
 
         if self.debug > 1:
 #            time.sleep(1)
@@ -101,7 +105,8 @@ class Robot:
         count = 0
 
         self.open_hosts_page()
-        time.sleep(1)
+        self.browser.implicitly_wait(1)
+#        time.sleep(1)
         iteration = 1
         next_renewal = []
 
@@ -140,7 +145,8 @@ class Robot:
     def update_host(self, host_button, host_name):
         self.logger.log(f"Updating {host_name}")
         host_button.click()
-        time.sleep(3)
+        self.browser.implicitly_wait(3)
+#        time.sleep(3)
         intervention = False
         try:
             if self.browser.find_elements(By.XPATH, "//h2[@class='big']")[0].text == "Upgrade Now":


### PR DESCRIPTION
More elegant finding of username and password fields - no xpath;
Browser waits until login page is loaded - waiting max of 10 sec or until login section appears in browser (which one is faster but no more than 10sec)- If somebody has problems this could be increased to max of 20 or even 30 sec;;
Browser waits after login to load my.noip.com page (this is not dynamic-dns page), but the page which loads after login - didn't had time to make it with explicit wait so I made it with implicit wait of 1 sec. For explicit wait some characteristic element should be used; This time could be increased, but if so it will be better to be done with explicit wait

The code is tested and working by me, but would appreciate your test results for improvement.