### PR TITLE
Remove redundant $USER input

### DIFF
--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -4,8 +4,8 @@ SUDO=sudo
 LOGDIR=/var/log/noip-renew/$USER
 INSTDIR=/usr/local/bin
 INSTEXE=$INSTDIR/noip-renew-$USER.sh
-CRONJOB="30 0 * * *   $USER    $INSTEXE $LOGDIR"
-NEWCJOB="30 0 $1 $2 *   $USER    $INSTEXE $LOGDIR"
+CRONJOB="30 0 * * *   $INSTEXE $LOGDIR"
+NEWCJOB="30 0 $1 $2 *   $INSTEXE $LOGDIR"
 $SUDO crontab -u $USER -l | grep -v '/noip-renew*'  | $SUDO crontab -u $USER -
 if [[ $3 = "True" ]]; then
     ($SUDO crontab -u $USER -l; echo "$NEWCJOB") | $SUDO crontab -u $USER -


### PR DESCRIPTION
I actually don't understand the point of:  `$USER    $INSTEXE $LOGDIR`

The addition of $USER is redundant in lines 7 and 8.
I say this because the code does not allow this command to be inserted into a second user's crontab to be run as the first user.

First, `$SUDO crontab -u $USER -l` is creating the crontab entry in $USER's crontab.
This intrinsically means that the commands in the crontab will be run as $USER.
So why are we doubling down and saying that the $USER must run the command as $USER?