### PR TITLE
Remove redundant $USER input from setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ function config() {
     LOGDIR=/var/log/noip-renew/$USER
     INSTDIR=/usr/local/bin
     INSTEXE=$INSTDIR/noip-renew-$USER.sh
-    CRONJOB="0 1    * * *   $USER    $INSTEXE $LOGDIR"
+    CRONJOB="0 1    * * *   $INSTEXE $LOGDIR"
 }
 
 function install() {


### PR DESCRIPTION
Same change as #19. Forgot that the setup script also sets up a cron job with the same $USER setup.
I think I have it all now.