### PR TITLE
Version number

### DIFF
--- a/noip-renew.py
+++ b/noip-renew.py
@@ -190,6 +190,8 @@ class Robot:
 
     def run(self):
         rc = 0
+        version = "1.6.1"
+        self.logger.log(f"No-IP renew script version {version}")
         self.logger.log(f"Debug level: {self.debug}")
         try:
             self.login()


### PR DESCRIPTION
@neothematrix In run function I added version="1.6.1" and entry to print version number in log. You can alter version="1.6.1" by sed in hook. I think only post-commit hook will be enough to change version.
In the hook (which is shell script) you can extract version number with grep or sed, increase it and after that replace it with sed. all these automatically on commit changes.
It is also possible to change this manually. Changes in the last few releases concern setup.sh only and not python script, so you can have new release with new setup.sh, but python script is unchanged... but this could be confusing... Probably will be better if we have different version numbers about python script and setup.sh script 

Nevertheless, this way will be easier to identify if somebody is using old script version and has problems...